### PR TITLE
Fix arm unw_getcontext() missing increment

### DIFF
--- a/include/libunwind-arm.h
+++ b/include/libunwind-arm.h
@@ -271,9 +271,9 @@ unw_tdep_context_t;
    avoid altering any registers after unw_resume. */
 
 #ifdef __SOFTFP__
-#define VSTMIA "nop\n" /* align return address to value stored by stmia */
+#define VSTMIA "nop\n\t" /* align return address to value stored by stmia */
 #else
-#define VSTMIA "vstmia %[base], {d0-d15}\n" /* this also aligns return address to value stored by stmia */
+#define VSTMIA "vstmia %[base], {d0-d15}\n\t" /* this also aligns return address to value stored by stmia */
 #endif
 
 #ifndef __thumb__
@@ -282,32 +282,32 @@ unw_tdep_context_t;
   register unsigned long *r0 __asm__ ("r0");                                                    \
   register unsigned long *unw_base __asm__ ("r1") = unw_ctx->regs;                              \
   __asm__ __volatile__ (                                                                        \
-    "mov r0, #0\n"                                                                              \
-    "stmia %[base]!, {r0-r15}\n"                                                                \
+    "mov r0, #0\n\t"                                                                            \
+    "stmia %[base]!, {r0-r15}\n\t"                                                              \
     VSTMIA                                                                                      \
     : [r0] "=r" (r0) : [base] "r" (unw_base) : "memory");                                       \
   (int)r0; })
 #else /* __thumb__ */
-#define unw_tdep_getcontext(uc) ({                                      \
-  unw_tdep_context_t *unw_ctx = (uc);                                   \
-  register unsigned long *r0 __asm__ ("r0");                            \
-  register unsigned long *unw_base __asm__ ("r1") = unw_ctx->regs;      \
-  __asm__ __volatile__ (                                                \
-    ".align 2\n"                                                        \
-    "bx pc\n"                                                           \
-    "nop\n"                                                             \
-    ".code 32\n"                                                        \
-    "mov r0, #0\n"                                                      \
-    "stmia %[base], {r0-r14}\n"                                         \
-    "adr r0, ret%=+1\n"                                                 \
-    "stmia %[base]!, {r0}\n"                                            \
-    VSTMIA                                                              \
-    "orr r0, pc, #1\n"                                                  \
-    "bx r0\n"                                                           \
-    ".code 16\n"                                                        \
-    "mov r0, #0\n"                                                      \
-    "ret%=:\n"                                                          \
-    : [r0] "=r" (r0), [base] "+r" (unw_base) : : "memory", "cc");       \
+#define unw_tdep_getcontext(uc) ({                                        \
+  unw_tdep_context_t *unw_ctx = (uc);                                     \
+  register unsigned long *r0 __asm__ ("r0");                              \
+  register unsigned long *unw_base __asm__ ("r1") = unw_ctx->regs;        \
+  __asm__ __volatile__ (                                                  \
+    ".align 2\n\t"                                                        \
+    "bx pc\n\t"                                                           \
+    "nop\n\t"                                                             \
+    ".code 32\n\t"                                                        \
+    "mov r0, #0\n\t"                                                      \
+    "stmia %[base]!, {r0-r14}\n\t"                                        \
+    "adr r0, ret%=+1\n\t"                                                 \
+    "stmia %[base]!, {r0}\n\t"                                            \
+    VSTMIA                                                                \
+    "orr r0, pc, #1\n\t"                                                  \
+    "bx r0\n\t"                                                           \
+    ".code 16\n\t"                                                        \
+    "mov r0, #0\n\t"                                                      \
+    "ret%=:\n"                                                            \
+    : [r0] "=r" (r0), [base] "+r" (unw_base) : : "memory", "cc");         \
   (int)r0; })
 #endif
 

--- a/tests/Ltest-init-local-signal.c
+++ b/tests/Ltest-init-local-signal.c
@@ -9,6 +9,8 @@
 #include <stdio.h>
 #include <assert.h>
 
+static const int max_steps = 10;
+
 int stepper(unw_cursor_t* c) {
   int steps = 0;
   int ret = 1;
@@ -19,6 +21,7 @@ int stepper(unw_cursor_t* c) {
       break;
     }
     steps++;
+    if (steps > max_steps) break;
   }
   return steps;
 }


### PR DESCRIPTION
Previous changes to save floating-point registers missed adding postincrement to the STM command so the floating-point regs were overwriting the integer regs.