### PR TITLE
Fix FTBFS on Linux ppc32

### DIFF
--- a/src/ppc32/ucontext_i.h
+++ b/src/ppc32/ucontext_i.h
@@ -44,8 +44,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 //#define MQ_IDX                36
 #define LINK_IDX        36
 
-#define _UC_MCONTEXT_GPR(x) ( (void *)&dmy_ctxt.uc_mcontext.gregs[x] - (void *)&dmy_ctxt) )
-#define _UC_MCONTEXT_FPR(x) ( ((void *)&dmy_ctxt.uc_mcontext.fpregs[x] - (void *)&dmy_ctxt) )
+#define _UC_MCONTEXT_GPR(x) ( ((void *)&dmy_ctxt.uc_mcontext.uc_regs->gregs[x] - (void *)&dmy_ctxt) )
+#define _UC_MCONTEXT_FPR(x) ( ((void *)&dmy_ctxt.uc_mcontext.uc_regs->fpregs.fpregs[x] - (void *)&dmy_ctxt) )
 
 /* These are dummy structures used only for obtaining the offsets of the
    various structure members. */


### PR DESCRIPTION
Looks like the Linux ucontext structure has changed for PPC at some point. This probably needs some kind of version check, or else ancient kernels will need to stick with 1.6 or earlier.