### PR TITLE
Configure -lpthread always for FreeBSD

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -215,9 +215,9 @@ AM_COND_IF([CONFIG_TESTS], [
   AC_SEARCH_LIBS([dlopen], [dl],
                  [AS_IF([test "$ac_cv_search_dlopen" != "none required"],
                         [AC_SUBST([DLLIB], ["$ac_cv_search_dlopen"])])])
-  AC_SEARCH_LIBS([pthread_key_create], [pthread],
-                 [AS_IF([test "$ac_cv_search_pthread_key_create" != "none required"],
-                        [AC_SUBST([PTHREADS_LIB], ["$ac_cv_search_pthread_key_create"])])])
+  AC_SEARCH_LIBS([pthread_create], [pthread],
+                 [AS_IF([test "$ac_cv_search_pthread_create" != "none required"],
+                        [AC_SUBST([PTHREADS_LIB],["$ac_cv_search_pthread_create"])])])
   AC_SEARCH_LIBS([backtrace], [execinfo],
                  [AS_IF([test "$ac_cv_search_backtrace" != "none required"],
                         [AC_SUBST([BACKTRACELIB],["$ac_cv_search_backtrace"])])])


### PR DESCRIPTION
The FreeBSD linker does not complain when libraries are underlinked, so the AC_SEARCH_LIBS autoconf test fails and "make check" fails. The solution is to always for -lpthreads for FreeBSD.